### PR TITLE
ERR - requires a `DialogTitle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 - https://www.prisma.io/
 - https://orm.drizzle.team/docs/get-started
 
+### ERR
+- https://radix-ui.com/primitives/docs/components/dialog
 
 ---
 ## Next.js App Router Course - Starter

--- a/components/my/yourFirstChart.tsx
+++ b/components/my/yourFirstChart.tsx
@@ -1,8 +1,8 @@
 "use client"
 
 import { Bar, BarChart } from "recharts"
-
 import { ChartConfig, ChartContainer } from "@/components/ui/chart"
+import { mFont } from '@/app/ui/fonts';
 
 const chartData = [
   { month: "January", desktop: 186, mobile: 80 },
@@ -26,11 +26,16 @@ const chartConfig = {
 
 export function YourFirstChart() {
   return (
+    <div className="w-full md:col-span-4">
+    <h2 className={`${mFont.className} mb-4 text-xl md:text-2xl`}>
+      <strong>S</strong>HADCN Chart
+    </h2>
     <ChartContainer config={chartConfig} className="min-h-[200px] w-full">
       <BarChart accessibilityLayer data={chartData}>
         <Bar dataKey="desktop" fill="var(--color-desktop)" radius={4} />
         <Bar dataKey="mobile" fill="var(--color-mobile)" radius={4} />
       </BarChart>
     </ChartContainer>
+    </div>
   )
 }


### PR DESCRIPTION
`DialogContent` requires a `DialogTitle` for the component to be accessible for screen reader users.

If you want to hide the `DialogTitle`, you can wrap it with our VisuallyHidden component.

For more information, see https://radix-ui.com/primitives/docs/components/dialog


![image](https://github.com/user-attachments/assets/8a251d3d-3326-478f-a68f-828971884b47)
